### PR TITLE
Reefersleep any

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject re-pressed "0.2.0"
+(defproject re-pressed "0.2.1-reefersleep-any"
   :description "A keyboard events library for re-frame"
   :url "https://github.com/gadfly361/re-pressed"
   :license {:name "MIT"}

--- a/src/main/re_pressed/impl.cljs
+++ b/src/main/re_pressed/impl.cljs
@@ -37,8 +37,11 @@
 (defn is-key?
   [recent-key key-map]
   (every? (fn [[k v]]
-            (= (get recent-key k)
-               v))
+            (let [same-kv? (= (get recent-key k)
+                              v)]
+              (or same-kv?
+                  (when (= :which k)
+                    (= :any v)))))
           key-map))
 
 


### PR DESCRIPTION
Hey, was curious if you wanted to try this out and see if it works for your use case. If it does, I'll get it merged in to re-pressed proper.

To use, you'd need to merge it in, then run `lein install`, then require `[re-pressed "0.2.1-reefersleep-any"].